### PR TITLE
Update README.md to mention gulp requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 
 This repository contains sample applications customized for Visual Studio Code. Each sample is a self contained workspace with configuration files specific to that folder. 
 
+These examples require [gulp](http://gulpjs.com/) to be installed on your path.  If you don't already have this installed then you can install like so: (you may need administrator rights to do this)
+
+```
+npm install -g gulp
+```
+
 To get started, cd into the sample directory, run `npm install` to install any necessary dependencies, and then start code:
 
 ``` bash


### PR DESCRIPTION
Without gulp installed globally you receive this error when you attempt to run tasks (eg `watch`):

> 'gulp' is not recognized as an internal or external command,
> operable program or batch file.
